### PR TITLE
Modify a page immediately, don't wait until the browser has finished its loading

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@
     "chrome": true
   },
   "rules": {
+    "no-loop-func": 0,
     "no-param-reassign": 0,
     "no-unused-vars": 0,
     "no-undef": 0

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,6 @@
     "chrome": true
   },
   "rules": {
-    "no-loop-func": 0,
     "no-param-reassign": 0,
     "no-unused-vars": 0,
     "no-undef": 0

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6,27 +6,5 @@
   "appDescription": {
     "message": "Adds Codeforces-style friending to the Timus Online Judge.",
     "description": "The description of the application"
-  },
-  "friends_ranklist": {
-    "message": "Friends ranklist",
-    "description": ""
-  },
-  "follow": {
-    "message": "Add to friends",
-    "description": ""
-  },
-  "unfollow": {
-    "message": "Remove from friends",
-    "description": ""
-  },
-  "no_friends": {
-    "message": "Use the $star$ icon to add friends.",
-    "description": "Shown when the user has no friends",
-    "placeholders": {
-      "star": {
-        "content": "$1",
-        "example": "The placeholder will be replaced with the actual star icon."
-      }
-    }
   }
 }

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -6,27 +6,5 @@
   "appDescription": {
     "message": "Добавляет рейтинг друзей на Timus Online Judge.",
     "description": "The description of the application"
-  },
-  "friends_ranklist": {
-    "message": "Рейтинг друзей",
-    "description": ""
-  },
-  "follow": {
-    "message": "Добавить в друзья",
-    "description": ""
-  },
-  "unfollow": {
-    "message": "Удалить из друзей",
-    "description": ""
-  },
-  "no_friends": {
-    "message": "Используйте кнопку $star$, чтобы добавить друзей.",
-    "description": "Shown when the user has no friends",
-    "placeholders": {
-      "star": {
-        "content": "$1",
-        "example": "The placeholder will be replaced with the actual star icon."
-      }
-    }
   }
 }

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -60,7 +60,7 @@
         "scripts/friends.js"
       ],
       "css": ["styles/friends.css"],
-      "run_at": "document_end"
+      "run_at": "document_start"
     }
   ]
 }

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -18,20 +18,22 @@
     {
       "matches": ["*://acm.timus.ru/*"],
       "js": [
+        "scripts/element_observer.js",
         "scripts/common.js",
         "scripts/menu.js"
       ],
       "css": ["styles/button.css"],
-      "run_at": "document_end"
+      "run_at": "document_start"
     },
     {
       "matches": ["*://acm.timus.ru/author.aspx?*"],
       "js": [
+        "scripts/element_observer.js",
         "scripts/common.js",
         "scripts/author.js",
         "scripts/ranklist.js"
       ],
-      "run_at": "document_end"
+      "run_at": "document_start"
     },
     {
       "matches": [
@@ -40,14 +42,16 @@
       ],
       "exclude_matches": ["*://acm.timus.ru/ranklist.aspx?friends*"],
       "js": [
+        "scripts/element_observer.js",
         "scripts/common.js",
         "scripts/ranklist.js"
       ],
-      "run_at": "document_end"
+      "run_at": "document_start"
     },
     {
       "matches": ["*://acm.timus.ru/ranklist.aspx?friends*"],
       "js": [
+        "scripts/element_observer.js",
         "scripts/common.js",
         "scripts/friends.js"
       ],

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -19,6 +19,7 @@
       "matches": ["*://acm.timus.ru/*"],
       "js": [
         "scripts/element_observer.js",
+        "scripts/locales.js",
         "scripts/common.js",
         "scripts/menu.js"
       ],
@@ -29,6 +30,7 @@
       "matches": ["*://acm.timus.ru/author.aspx?*"],
       "js": [
         "scripts/element_observer.js",
+        "scripts/locales.js",
         "scripts/common.js",
         "scripts/author.js",
         "scripts/ranklist.js"
@@ -43,6 +45,7 @@
       "exclude_matches": ["*://acm.timus.ru/ranklist.aspx?friends*"],
       "js": [
         "scripts/element_observer.js",
+        "scripts/locales.js",
         "scripts/common.js",
         "scripts/ranklist.js"
       ],
@@ -52,15 +55,12 @@
       "matches": ["*://acm.timus.ru/ranklist.aspx?friends*"],
       "js": [
         "scripts/element_observer.js",
+        "scripts/locales.js",
         "scripts/common.js",
         "scripts/friends.js"
       ],
       "css": ["styles/friends.css"],
       "run_at": "document_end"
     }
-  ],
-  "web_accessible_resources": [
-    "_locales/ru/messages.json",
-    "_locales/en/messages.json"
   ]
 }

--- a/app/scripts.babel/author.js
+++ b/app/scripts.babel/author.js
@@ -1,5 +1,5 @@
-init({ friends: true }, ({ friends }) => {
+init({ friends: true }, ({ observer, friends }) => {
   const profileId = getQueryVariable('id');
   const button = createButton(friends.hasOwnProperty(profileId), profileId);
-  document.querySelector('.author_name').appendChild(button);
+  observer.forEach('.author_name', elem => elem.appendChild(button));
 });

--- a/app/scripts.babel/author.js
+++ b/app/scripts.babel/author.js
@@ -1,5 +1,5 @@
-init({ friends: true }, ({ observer, friends }) => {
+init({ friends: true }, ({ friends }) => {
   const profileId = getQueryVariable('id');
   const button = createButton(friends.hasOwnProperty(profileId), profileId);
-  observer.forEach('.author_name', elem => elem.appendChild(button));
+  observer.forEach('.author_name', el => el.appendChild(button));
 });

--- a/app/scripts.babel/common.js
+++ b/app/scripts.babel/common.js
@@ -1,3 +1,6 @@
+const observer = new ElementObserver();
+observer.observe();
+
 function ajax(options, callback) {
   const request = new XMLHttpRequest();
   request.open(options.method, options.url, options.async || true);
@@ -13,21 +16,22 @@ function ajax(options, callback) {
   return request.send(options.data);
 }
 
-function getSiteLocale() {
-  return /Задачи/.test(document.querySelector('body').innerText) ? 'ru' : 'en';
+function getSiteLocale(callback) {
+  // observer.forEach('.panel a[href="/news.aspx"]', newsLink =>
+  //   callback(newsLink.innerText === 'Site news' ? 'en' : 'ru'));
+  callback('en');
 }
 
 let messageBundle;
 
 function loadMessageBundle(callback) {
-  const locale = getSiteLocale();
-  ajax({
+  getSiteLocale(locale => ajax({
     method: 'GET',
     url: chrome.runtime.getURL(`_locales/${locale}/messages.json`),
   }, response => {
     messageBundle = JSON.parse(response);
     callback();
-  });
+  }));
 }
 
 function getMessage(id) {
@@ -58,7 +62,7 @@ function injectCachedRanks(requires, data, callback) {
 
 function init(requires, callback) {
   loadMessageBundle(() => {
-    injectFriends(requires, {}, data => {
+    injectFriends(requires, { observer }, data => {
       injectCachedRanks(requires, data, callback);
     });
   });

--- a/app/scripts.babel/common.js
+++ b/app/scripts.babel/common.js
@@ -75,7 +75,7 @@ function injectCachedRanks(requires, data, callback) {
 
 function init(requires, callback) {
   loadMessageBundle(() => {
-    injectFriends(requires, { observer }, data => {
+    injectFriends(requires, {}, data => {
       injectCachedRanks(requires, data, callback);
     });
   });

--- a/app/scripts.babel/element_observer.js
+++ b/app/scripts.babel/element_observer.js
@@ -1,3 +1,5 @@
+const HANDLER_CLASS_PREFIX = 'handler_';
+
 class ElementObserver {
   constructor() {
     this._handlers = [];
@@ -8,21 +10,24 @@ class ElementObserver {
             continue;
           }
 
-          for (const item of this._handlers) {
-            if (node.matches(item.selector)) {
-              console.log('online ' + item.selector);
+          this._handlers.forEach((item, i) => {
+            if (node.matches(item.selector) &&
+                !node.classList.contains(HANDLER_CLASS_PREFIX + i)) {
+              // console.log('online ' + item.selector);
               item.handler(node);
             }
-          }
+          });
         }
       }
     });
   }
 
   forEach(selector, handler) {
+    const handlerId = this._handlers.length;
     for (const node of Array.from(document.querySelectorAll(selector))) {
-      console.log('offline ' + selector);
+      // console.log('offline ' + selector);
       handler(node);
+      node.classList.add(HANDLER_CLASS_PREFIX + handlerId);
     }
     this._handlers.push({ selector, handler });
   }

--- a/app/scripts.babel/element_observer.js
+++ b/app/scripts.babel/element_observer.js
@@ -1,0 +1,36 @@
+class ElementObserver {
+  constructor() {
+    this._handlers = [];
+    this._observer = new MutationObserver(mutations => {
+      for (const mutation of mutations) {
+        for (const node of Array.from(mutation.addedNodes)) {
+          if (!(node instanceof Element)) {
+            continue;
+          }
+
+          for (const item of this._handlers) {
+            if (node.matches(item.selector)) {
+              console.log('online ' + item.selector);
+              item.handler(node);
+            }
+          }
+        }
+      }
+    });
+  }
+
+  forEach(selector, handler) {
+    for (const node of Array.from(document.querySelectorAll(selector))) {
+      console.log('offline ' + selector);
+      handler(node);
+    }
+    this._handlers.push({ selector, handler });
+  }
+
+  observe() {
+    this._observer.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+    });
+  }
+}

--- a/app/scripts.babel/element_observer.js
+++ b/app/scripts.babel/element_observer.js
@@ -1,21 +1,30 @@
-const HANDLER_CLASS_PREFIX = 'tf__observer-';
+const ELEMENT_HANDLER_CLASS_PREFIX = 'tf__observer-element-';
+const TEXT_HANDLER_CLASS_PREFIX = 'tf__observer-text-';
 
 class ElementObserver {
+  static _invokeHandlers(handlers, classPrefix, matchedElement, passedNode) {
+    handlers.forEach(({ selector, handler }, i) => {
+      if (matchedElement.matches(selector) &&
+          !matchedElement.classList.contains(classPrefix + i)) {
+        handler(passedNode);
+      }
+    });
+  }
+
   constructor() {
-    this._handlers = [];
+    this._elementHandlers = [];
+    this._textHandlers = [];
     new MutationObserver(mutations => {
       mutations.forEach(mutation => {
         Array.from(mutation.addedNodes).forEach(node => {
-          if (!(node instanceof Element)) {
-            return;
+          if (node instanceof Element) {
+            ElementObserver._invokeHandlers(this._elementHandlers,
+              ELEMENT_HANDLER_CLASS_PREFIX, node, node);
+          } else
+          if (node instanceof Text && node.parentElement !== null) {
+            ElementObserver._invokeHandlers(this._textHandlers,
+              TEXT_HANDLER_CLASS_PREFIX, node.parentElement, node);
           }
-
-          this._handlers.forEach(({ selector, handler }, i) => {
-            if (node.matches(selector) &&
-                !node.classList.contains(HANDLER_CLASS_PREFIX + i)) {
-              handler(node);
-            }
-          });
         });
       });
     }).observe(document.documentElement, {
@@ -25,11 +34,24 @@ class ElementObserver {
   }
 
   forEach(selector, handler) {
-    const handlerId = this._handlers.length;
-    for (const node of Array.from(document.querySelectorAll(selector))) {
-      handler(node);
-      node.classList.add(HANDLER_CLASS_PREFIX + handlerId);
+    const handlerId = this._elementHandlers.length;
+    for (const el of Array.from(document.querySelectorAll(selector))) {
+      handler(el);
+      el.classList.add(ELEMENT_HANDLER_CLASS_PREFIX + handlerId);
     }
-    this._handlers.push({ selector, handler });
+    this._elementHandlers.push({ selector, handler });
+  }
+
+  forEachTextIn(selector, handler) {
+    const handlerId = this._textHandlers.length;
+    for (const el of Array.from(document.querySelectorAll(selector))) {
+      for (const node of el.childNodes) {
+        if (node instanceof Text) {
+          handler(node);
+        }
+      }
+      el.classList.add(TEXT_HANDLER_CLASS_PREFIX + handlerId);
+    }
+    this._textHandlers.push({ selector, handler });
   }
 }

--- a/app/scripts.babel/element_observer.js
+++ b/app/scripts.babel/element_observer.js
@@ -1,41 +1,35 @@
-const HANDLER_CLASS_PREFIX = 'handler_';
+const HANDLER_CLASS_PREFIX = 'tf__observer-';
 
 class ElementObserver {
   constructor() {
     this._handlers = [];
-    this._observer = new MutationObserver(mutations => {
-      for (const mutation of mutations) {
-        for (const node of Array.from(mutation.addedNodes)) {
+    new MutationObserver(mutations => {
+      mutations.forEach(mutation => {
+        Array.from(mutation.addedNodes).forEach(node => {
           if (!(node instanceof Element)) {
-            continue;
+            return;
           }
 
-          this._handlers.forEach((item, i) => {
-            if (node.matches(item.selector) &&
+          this._handlers.forEach(({ selector, handler }, i) => {
+            if (node.matches(selector) &&
                 !node.classList.contains(HANDLER_CLASS_PREFIX + i)) {
-              // console.log('online ' + item.selector);
-              item.handler(node);
+              handler(node);
             }
           });
-        }
-      }
+        });
+      });
+    }).observe(document.documentElement, {
+      childList: true,
+      subtree: true,
     });
   }
 
   forEach(selector, handler) {
     const handlerId = this._handlers.length;
     for (const node of Array.from(document.querySelectorAll(selector))) {
-      // console.log('offline ' + selector);
       handler(node);
       node.classList.add(HANDLER_CLASS_PREFIX + handlerId);
     }
     this._handlers.push({ selector, handler });
-  }
-
-  observe() {
-    this._observer.observe(document.documentElement, {
-      childList: true,
-      subtree: true,
-    });
   }
 }

--- a/app/scripts.babel/friends.js
+++ b/app/scripts.babel/friends.js
@@ -147,18 +147,16 @@ function showFriends({ friends, cachedRanks }) {
     const newRanklist = renderRanklist(header, friends);
     ranklist.parentElement.replaceChild(newRanklist, ranklist);
     ranklist = newRanklist;
-
-    Array.from(document.querySelectorAll(SELECTOR_TO_HIDE))
-      .forEach(el => el.style.display = '');
   }
 
-  document.title = getMessage('friends_ranklist');
   const pageBody = ranklist.parentElement.parentElement;
   pageBody.querySelector('.title').innerText = getMessage('friends_ranklist');
   pageBody.querySelector('div').remove(); // Volume navigation
 
   parseRanklistPage(document).forEach(loadProfile);
   replaceRanklist();
+  Array.from(document.querySelectorAll(SELECTOR_TO_HIDE))
+    .forEach(el => el.style.display = '');
 
   const pagesToLoad = {};
   Object.keys(friends).forEach(id => {
@@ -210,6 +208,10 @@ function showFriends({ friends, cachedRanks }) {
     }
   });
 }
+
+init({}, () => {
+  document.title = getMessage('friends_ranklist') + ' @ Timus Online Judge';
+});
 
 observer.forEach(SELECTOR_TO_HIDE, el => el.style.display = 'none');
 

--- a/app/scripts.babel/friends.js
+++ b/app/scripts.babel/friends.js
@@ -118,7 +118,9 @@ function cacheRanks(profiles) {
   chrome.runtime.sendMessage({ setCachedRanks: true, cachedRanks: ranks });
 }
 
-init({ friends: true, cachedRanks: true }, ({ friends, cachedRanks }) => {
+const SELECTOR_TO_HIDE = 'body > table > tbody > tr:nth-child(n+3)';
+
+function showFriends({ friends, cachedRanks }) {
   let loadingFriends = 0;
   Object.keys(friends).map(id => {
     friends[id] = { id, needsLoading: true };
@@ -145,6 +147,9 @@ init({ friends: true, cachedRanks: true }, ({ friends, cachedRanks }) => {
     const newRanklist = renderRanklist(header, friends);
     ranklist.parentElement.replaceChild(newRanklist, ranklist);
     ranklist = newRanklist;
+
+    Array.from(document.querySelectorAll(SELECTOR_TO_HIDE))
+      .forEach(elem => elem.style.display = '');
   }
 
   document.title = getMessage('friends_ranklist');
@@ -203,5 +208,13 @@ init({ friends: true, cachedRanks: true }, ({ friends, cachedRanks }) => {
       friends[myId].me = true;
       replaceRanklist();
     }
+  });
+}
+
+observer.forEach(SELECTOR_TO_HIDE, elem => elem.style.display = 'none');
+
+init({ friends: true, cachedRanks: true }, data => {
+  document.addEventListener('DOMContentLoaded', () => {
+    showFriends(data);
   });
 });

--- a/app/scripts.babel/friends.js
+++ b/app/scripts.babel/friends.js
@@ -149,7 +149,7 @@ function showFriends({ friends, cachedRanks }) {
     ranklist = newRanklist;
 
     Array.from(document.querySelectorAll(SELECTOR_TO_HIDE))
-      .forEach(elem => elem.style.display = '');
+      .forEach(el => el.style.display = '');
   }
 
   document.title = getMessage('friends_ranklist');
@@ -211,7 +211,7 @@ function showFriends({ friends, cachedRanks }) {
   });
 }
 
-observer.forEach(SELECTOR_TO_HIDE, elem => elem.style.display = 'none');
+observer.forEach(SELECTOR_TO_HIDE, el => el.style.display = 'none');
 
 init({ friends: true, cachedRanks: true }, data => {
   document.addEventListener('DOMContentLoaded', () => {

--- a/app/scripts.babel/locales.js
+++ b/app/scripts.babel/locales.js
@@ -16,6 +16,6 @@ const MESSAGES = {
 };
 
 function getSiteMessages(callback) {
-  observer.forEach('.panel a[href="/news.aspx"]', newsLink =>
-    callback(MESSAGES[newsLink.innerText === 'Site news' ? 'en' : 'ru']));
+  observer.forEachTextIn('.panel a[href="/news.aspx"]', newsLabel =>
+    callback(MESSAGES[newsLabel.textContent === 'Site news' ? 'en' : 'ru']));
 }

--- a/app/scripts.babel/locales.js
+++ b/app/scripts.babel/locales.js
@@ -1,0 +1,21 @@
+// We can't use messages.json for these messages because the locale for them
+// depends on the site content
+const MESSAGES = {
+  en: {
+    friends_ranklist: 'Friends ranklist',
+    follow: 'Add to friends',
+    unfollow: 'Remove from friends',
+    no_friends: 'Use the $star$ icon to add friends.',
+  },
+  ru: {
+    friends_ranklist: 'Рейтинг друзей',
+    follow: 'Добавить в друзья',
+    unfollow: 'Удалить из друзей',
+    no_friends: 'Используйте кнопку $star$, чтобы добавить друзей.',
+  },
+};
+
+function getSiteMessages(callback) {
+  observer.forEach('.panel a[href="/news.aspx"]', newsLink =>
+    callback(MESSAGES[newsLink.innerText === 'Site news' ? 'en' : 'ru']));
+}

--- a/app/scripts.babel/menu.js
+++ b/app/scripts.babel/menu.js
@@ -3,8 +3,9 @@ init({}, () => {
   friendsLink.href = '/ranklist.aspx?friends&count=1000';
   friendsLink.innerText = getMessage('friends_ranklist');
 
-  const ranklistLink = document.querySelector('a[href="/ranklist.aspx"]');
-  ranklistLink.href += '?count=25';
-  ranklistLink.parentElement.insertBefore(friendsLink, ranklistLink.nextSibling);
-  ranklistLink.parentElement.insertBefore(document.createElement('br'), friendsLink);
+  observer.forEach('.panel a[href="/ranklist.aspx"]', ranklistLink => {
+    ranklistLink.href += '?count=25';
+    ranklistLink.parentElement.insertBefore(friendsLink, ranklistLink.nextSibling);
+    ranklistLink.parentElement.insertBefore(document.createElement('br'), friendsLink);
+  });
 });

--- a/app/scripts.babel/ranklist.js
+++ b/app/scripts.babel/ranklist.js
@@ -1,7 +1,7 @@
-init({ friends: true }, ({ friends }) => {
-  Array.from(document.querySelectorAll('.ranklist tr.content td.name')).forEach(td => {
-    const profileLink = td.querySelector('a');
+init({ friends: true }, ({ observer, friends }) => {
+  observer.forEach('.ranklist tr.content td.name a', profileLink => {
     const profileId = getQueryVariable('id', profileLink.getAttribute('href'));
+    const td = profileLink.parentElement;
     td.appendChild(createButton(friends.hasOwnProperty(profileId), profileId));
   });
 });

--- a/app/scripts.babel/ranklist.js
+++ b/app/scripts.babel/ranklist.js
@@ -1,4 +1,4 @@
-init({ friends: true }, ({ observer, friends }) => {
+init({ friends: true }, ({ friends }) => {
   observer.forEach('.ranklist tr.content td.name a', profileLink => {
     const profileId = getQueryVariable('id', profileLink.getAttribute('href'));
     const td = profileLink.parentElement;


### PR DESCRIPTION
In the current version of the extension the browser firstly shows an original website page, waits until the DOM is complete, and then runs the extension to modify the page. As a result, the page contents is blinking, and this can harm the user experience.

I suggest to run the extension at `document_start` instead of `document_end` and use MutationObserver to catch adding of the elements and modify them. In this case elements are shown modified since their appearance.

Note that to reach the described effects, MutationObserver callbacks can't be asynchronous. So the code was refactored to retrieve a friend list and locale messages in a synchronous way.
